### PR TITLE
Add a flag for running in billing-only mode 

### DIFF
--- a/cloudformation/stacks/AutoSpotting/template.yaml
+++ b/cloudformation/stacks/AutoSpotting/template.yaml
@@ -1076,6 +1076,9 @@
               - ':'
               - - Fn::GetAtt: ECRRepository.RepositoryUri
                 - Ref: SourceImageTag
+            Environment:
+            - Name: BILLING_ONLY
+              Value: "true"
             LogConfiguration:
               LogDriver: awslogs
               Options:

--- a/core/config.go
+++ b/core/config.go
@@ -120,6 +120,9 @@ type Config struct {
 
 	// DisableInstanceRebalanceRecommendation disable the handling of Instance Rebalance Recommendation events.
 	DisableInstanceRebalanceRecommendation bool
+
+	// BillingOnly - only billing related actions will be taken, no instance replacement will be performed.
+	BillingOnly bool
 }
 
 // ParseConfig loads configuration from command line flags, environments variables, and config files.
@@ -266,6 +269,11 @@ func ParseConfig(conf *Config) {
 			"\tFurther information on this is available at "+
 			"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html\n"+
 			"\tExample: ./AutoSpotting --spot_allocation_strategy capacity-optimized-prioritized\n")
+
+	flagSet.BoolVar(&conf.BillingOnly, "billing_only", false,
+		"\n\tControls whether AutoSpotting only does the Marketplace billing without taking any further\n"+
+			"replacement actions when executed in cron mode\n"+
+			"\tExample: ./AutoSpotting --billing_only true\n")
 
 	printVersion := flagSet.Bool("version", false, "Print version number and exit.\n")
 

--- a/core/main.go
+++ b/core/main.go
@@ -150,6 +150,11 @@ func (a *AutoSpotting) processRegions(regions []string) {
 		log.Println("Not running a stable build, skipped AWS marketplace metering")
 	}
 
+	if a.config.BillingOnly {
+		log.Println("Billing only mode enabled, exiting...")
+		return
+	}
+
 	for _, r := range regions {
 		wg.Add(1)
 		r := region{name: r, conf: a.config}


### PR DESCRIPTION
# Issue Type

<!--
Pick one below and delete the others.

Also feel free to delete these comments for brevity once they were fully
acknowledged.
-->

- Bugfix Pull Request

## Summary

Someone reported instance replacements on groups tagged with spot-enabled=true even though the Lambda was configured with another tag.

Turns out the replacements were done by the billing Fargate task which ran without any filters and applied changes to groups tagged with the default tag spot-enabled=true

This commit adds a flag that disable any instance replacements and sets if on the Fargate task, in order to avoid undesired instance replacements


<!--
Describe the change, including rationale and design decisions, and use a brief
but descriptive PR title.

Please include "Fixes #nnn" here or in your commit message in order to
link to an issue in which you describe the addressed problem in more detail.

If you want to address more issues do it in different pull requests instead of a
single big one, it will speed up the review process considerably.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

The label should be set by a maintainer as soon as the review is requested on
Gitter and should only be cleared after the PR is merged.
-->

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [ ] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
