### PR TITLE
Switch Lambda and Fargate to arm64

### DIFF
--- a/CUSTOM_BUILDS.md
+++ b/CUSTOM_BUILDS.md
@@ -46,10 +46,14 @@ AutoSpotting uses a Lambda function configured to use a Docker image. Such a
 configuration [currently](https://github.com/aws/containers-roadmap/issues/1281)
 requires the Docker image to be stored in an ECR from your own account.
 
-Also, in order for the generated Docker image to be compatible with the Lambda
-runtime, the image must currently be built on a x86_64 host. Unfortunately ARM
-hosts such as Apple M1 Macbook aren't currently supported because of QEMU
-emulator crashes when performing the cross-compilation using `docker buildx`.
+AutoSpotting trunk currently builds and runs by default as ARM binaries.
+Building it locally most probably requires a `docker buildx` setup, as per the
+official Docker
+[documentation](https://docs.docker.com/buildx/working-with-buildx/). The
+Marketplace version is currently available only at x86 binaries.
+
+Building it as Intel binaries is still possible, but the infrastructure code
+will currently expect ARM binaries.
 
 In order to support the AWS Marketplace setup, which relies on an ECR repository
 hosted in another AWS-managed account, the current CloudFormation template uses
@@ -59,14 +63,14 @@ some complexity but has the nice side effect of being able to push the image to
 any arbitrary ECR in another account/region, offering more flexibility for
 customers who may want to manage custom deployments at scale.
 
-You'll therefore need to build an x86_64 Docker image, upload it to an ECR
+You'll therefore need to build an ARM Docker image, upload it to an ECR
 repository in your AWS account and configure your CloudFormation or Terraform
 stack to use this new image as a source image.
 
 1. Set up an ECR repository in your AWS account that will host your custom
    Docker images.
 
-1. The build system can use a `DOCKER_IMAGE` variable that tells it where to
+2. The build system can use a `DOCKER_IMAGE` variable that tells it where to
    upload the image. Set it into your environment to the name of your ECR
    repository. When unset you'll attempt to push to the Marketplace ECR and
    you'll receive permission errors.
@@ -76,23 +80,23 @@ stack to use this new image as a source image.
    export DOCKER_IMAGE_VERSION=1.0.2 # it's strongly recommended versioning images
    ```
 
-1. Define some AWS credentials or profile information into your
+3. Define some AWS credentials or profile information into your
    [environment](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-environment).
 
-1. Authenticate to your ECR repository
+4. Authenticate to your ECR repository
 
    ```shell
    make docker-login
    ```
 
-1. Build and upload your Docker image to your ECR and configure a CloudFormation
+5. Build and upload your Docker image to your ECR and configure a CloudFormation
    template to use your ECR
 
    ``` shell
    make docker-push-artifacts
    ```
 
-1. Use the CloudFormation template from the `build` directory to create the
+6. Use the CloudFormation template from the `build` directory to create the
    resources. Make sure you set the parameters `SourceECR` and `SourceImage` to
    point to your ECR repository (`SourceECR` should be set to contain the
    hostname part of your ECR repository, before the first `/` character and

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ artifacts:                                       			 ## Create CloudFormation ar
 .PHONY: artifacts
 
 docker: 													 ##  Build a Docker image, currently only supports x86 hosts
-	docker build --build-arg flavor=$(FLAVOR) --platform=linux/arm64 --push -t $(DOCKER_IMAGE):$(DOCKER_IMAGE_VERSION) .
+	docker build --build-arg flavor=$(FLAVOR) --platform=linux/$(GOARCH) --push -t $(DOCKER_IMAGE):$(DOCKER_IMAGE_VERSION) .
 .PHONY: docker
 
 docker-login:
@@ -77,7 +77,7 @@ docker-push-artifacts: docker artifacts
 .PHONY: docker-push-artifacts
 
 docker-marketplace:
-	docker build -f Dockerfile.marketplace --platform=linux/arm64 --push -t $(DOCKER_IMAGE):$(DOCKER_IMAGE_VERSION) --build-arg savings_cut=${SAVINGS_CUT} .
+	docker build -f Dockerfile.marketplace --platform=linux/$(GOARCH) --push -t $(DOCKER_IMAGE):$(DOCKER_IMAGE_VERSION) --build-arg savings_cut=${SAVINGS_CUT} .
 .PHONY: docker-marketplace
 
 docker-marketplace-push-artifacts: docker-marketplace artifacts

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILD := $(DOCKER_IMAGE_VERSION)-$(FLAVOR)-$(SHA)
 EXPIRATION := $(shell go run ./scripts/expiration_date.go)
 SAVINGS_CUT ?= 5
 
-GOARCH ?= amd64
+GOARCH ?= arm64
 
 ifneq ($(FLAVOR), custom)
     LICENSE_FILES += BINARY_LICENSE
@@ -67,7 +67,7 @@ artifacts:                                       			 ## Create CloudFormation ar
 .PHONY: artifacts
 
 docker: 													 ##  Build a Docker image, currently only supports x86 hosts
-	docker build --build-arg flavor=$(FLAVOR) --platform=linux/amd64 --push -t $(DOCKER_IMAGE):$(DOCKER_IMAGE_VERSION) .
+	docker build --build-arg flavor=$(FLAVOR) --platform=linux/arm64 --push -t $(DOCKER_IMAGE):$(DOCKER_IMAGE_VERSION) .
 .PHONY: docker
 
 docker-login:
@@ -77,7 +77,7 @@ docker-push-artifacts: docker artifacts
 .PHONY: docker-push-artifacts
 
 docker-marketplace:
-	docker build -f Dockerfile.marketplace --platform=linux/amd64 --push -t $(DOCKER_IMAGE):$(DOCKER_IMAGE_VERSION) --build-arg savings_cut=${SAVINGS_CUT} .
+	docker build -f Dockerfile.marketplace --platform=linux/arm64 --push -t $(DOCKER_IMAGE):$(DOCKER_IMAGE_VERSION) --build-arg savings_cut=${SAVINGS_CUT} .
 .PHONY: docker-marketplace
 
 docker-marketplace-push-artifacts: docker-marketplace artifacts

--- a/cloudformation/stacks/AutoSpotting/template.yaml
+++ b/cloudformation/stacks/AutoSpotting/template.yaml
@@ -356,6 +356,8 @@
         - CopyDockerImage
       Properties:
         PackageType: Image
+        Architectures:
+          - arm64
         Code:
           ImageUri:
             Fn::Join:
@@ -1065,6 +1067,8 @@
         # Between 4GB and 16GB in 1GB increments - Available cpu values: 2048 (2 vCPU)
         # Between 8GB and 30GB in 1GB increments - Available cpu values: 4096 (4 vCPU)
         Memory: 0.5GB
+        RuntimePlatform:
+          CpuArchitecture: ARM64
         ExecutionRoleArn:
           Ref: ECSTaskExecutionRole
         TaskRoleArn:


### PR DESCRIPTION
# Issue Type

<!--
Pick one below and delete the others.

Also feel free to delete these comments for brevity once they were fully
acknowledged.
-->

- Feature Pull Request

## Summary

This makes AutoSpotting build and run as ARM binaries, which makes it slightly cheaper and faster at runtime, and also friendlier to my current local development setup. 

Intel binaries are still supported by the build process using the GOARCH environment variable, but the Infrastructure code will only deploy ARM infrastructure, which is not currently configurable.

Caveats:
- This will make the build process require a `docker buildx` setup on Intel hardware
- It will make it slower to build AutoSpotting on Intel-based hardware.

If you're interested to add support making the infrastructure code configurable as well, patches are always welcome.

<!--
Describe the change, including rationale and design decisions, and use a brief
but descriptive PR title.

Please include "Fixes #nnn" here or in your commit message in order to
link to an issue in which you describe the addressed problem in more detail.

If you want to address more issues do it in different pull requests instead of a
single big one, it will speed up the review process considerably.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

The label should be set by a maintainer as soon as the review is requested on
Gitter and should only be cleared after the PR is merged.
-->

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [n/a] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [n/a] No issues are reported when running `make full-test`.
1. [n/a] Functionality not applicable to all users should be configurable.
1. [n/a] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [n/a] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [n/a] Tags names and expected values should be similar to the other existing
   configurations.
1. [n/a] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [n/a] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
